### PR TITLE
The delete() function should not take data

### DIFF
--- a/src/RequestsLibrary/keywords.py
+++ b/src/RequestsLibrary/keywords.py
@@ -129,7 +129,7 @@ class RequestsKeywords(object):
         return resp
 
 
-    def delete(self, alias, uri, headers=None):
+    def delete(self, alias, uri, data=(), headers=None):
         """ Send a DELETE request on the session object found using the given `alias`
 
         `alias` that will be used to identify the Session object in the cache


### PR DESCRIPTION
Removed data from the arguments list of the delete function. Data are not really supported for delete requests and the url concatenation using data was wrong, it appended a question mark to the last url parameter. Workaround is to pass an empty list as data as long as we have no new version.
