### PR TITLE
Add requests support version in ReadMe file

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@ Usage
 
 You need to have requests installed
 
-``` pip install -U requests```
+NOTE: Only support requests 0.9.0 or lower
+
+``` pip install -U requests==0.9.0```
 
 Now install robotframework-requests
 


### PR DESCRIPTION
After install the latest build of requests, 1.0.4, when create session will get a error as:
TypeError: session() takes no arguments (6 given)
