### PR TITLE
Added auto-redirect control param on HTTP methods

### DIFF
--- a/src/RequestsLibrary/RequestsKeywords.py
+++ b/src/RequestsLibrary/RequestsKeywords.py
@@ -152,7 +152,7 @@ class RequestsKeywords(object):
             url = "%s%s%s" %(session.url, slash, uri)
         return url
 
-    def get(self, alias, uri, headers=None, cassette=None, params={}):
+    def get(self, alias, uri, headers=None, cassette=None, params={}, allow_redirects=None):
         """ Send a GET request on the session object found using the
             given `alias`
 
@@ -164,16 +164,17 @@ class RequestsKeywords(object):
         """
         session = self._cache.switch(alias)
         params = self._utf8_urlencode(params)
+        redir = True if allow_redirects is None else allow_redirects
         if cassette:
             with vcr.use_cassette(cassette, serializer='json', cassette_library_dir = 'cassettes/GET', record_mode='new_episodes', match_on=['url', 'method', 'headers', 'body']):
-                response = self.get_request(session, uri, headers, params)
+                response = self.get_request(session, uri, headers, params, redir)
         else:
-            response = self.get_request(session, uri, headers, params)
+            response = self.get_request(session, uri, headers, params, redir)
 
         return response
 
 
-    def post(self, alias, uri, data={}, headers=None, files={}, cassette=None):
+    def post(self, alias, uri, data={}, headers=None, files={}, cassette=None, allow_redirects=None):
         """ Send a POST request on the session object found using the
         given `alias`
 
@@ -191,15 +192,16 @@ class RequestsKeywords(object):
         """
         session = self._cache.switch(alias)
         data = self._utf8_urlencode(data)
+        redir = True if allow_redirects is None else allow_redirects
         if cassette:
             with vcr.use_cassette(cassette, serializer='json', cassette_library_dir = 'cassettes/POST', record_mode='new_episodes', match_on=['url', 'method', 'headers', 'body']):
-                response = self.post_request(session, uri, data, headers, files)
+                response = self.post_request(session, uri, data, headers, files, redir)
         else:
-            response = self.post_request(session, uri, data, headers, files)
+            response = self.post_request(session, uri, data, headers, files, redir)
 
         return response
 
-    def patch(self, alias, uri, data={}, headers=None, files={}, cassette=None):
+    def patch(self, alias, uri, data={}, headers=None, files={}, cassette=None, allow_redirects=None):
         """ Send a PATCH request on the session object found using the
         given `alias`
 
@@ -217,15 +219,16 @@ class RequestsKeywords(object):
         """
         session = self._cache.switch(alias)
         data = self._utf8_urlencode(data)
+        redir = True if allow_redirects is None else allow_redirects
         if cassette:
             with vcr.use_cassette(cassette, serializer='json', cassette_library_dir = 'cassettes/PATCH', record_mode='new_episodes', match_on=['url', 'method', 'headers', 'body']):
-                response = self.patch_request(session, uri, data, headers, files)
+                response = self.patch_request(session, uri, data, headers, files, redir)
         else:
-            response = self.patch_request(session, uri, data, headers, files)
+            response = self.patch_request(session, uri, data, headers, files, redir)
 
         return response
 
-    def put(self, alias, uri, data=None, headers=None, cassette=None):
+    def put(self, alias, uri, data=None, headers=None, cassette=None, allow_redirects=None):
         """ Send a PUT request on the session object found using the
         given `alias`
 
@@ -239,17 +242,18 @@ class RequestsKeywords(object):
 
         session = self._cache.switch(alias)
         data = self._utf8_urlencode(data)
+        redir = True if allow_redirects is None else allow_redirects
         if cassette:
             with vcr.use_cassette(cassette, serializer='json', cassette_library_dir = 'cassettes/PUT', record_mode='new_episodes', match_on=['url', 'method', 'headers', 'body']):
-                response = self.put_request(session, uri, data, headers)
+                response = self.put_request(session, uri, data, headers, redir)
         else:
-            response = self.put_request(session, uri, data, headers)
+            response = self.put_request(session, uri, data, headers, redir)
 
         return response
 
 
 
-    def delete(self, alias, uri, data=(), headers=None, cassette=None):
+    def delete(self, alias, uri, data=(), headers=None, cassette=None, allow_redirects=None):
         """ Send a DELETE request on the session object found using the
         given `alias`
 
@@ -263,17 +267,18 @@ class RequestsKeywords(object):
 
         session = self._cache.switch(alias)
         data = self._utf8_urlencode(data)
+        redir = True if allow_redirects is None else allow_redirects
         if cassette:
             with vcr.use_cassette(cassette, serializer='json', cassette_library_dir = 'cassettes/DELETE', record_mode='new_episodes', match_on=['url', 'method', 'headers', 'body']):
-                response = self.delete_request(session, uri, data, headers)
+                response = self.delete_request(session, uri, data, headers, redir)
         else:
-            response = self.delete_request(session, uri, data, headers)
+            response = self.delete_request(session, uri, data, headers, redir)
 
         return response
 
 
 
-    def head(self, alias, uri, headers=None, cassette=None):
+    def head(self, alias, uri, headers=None, cassette=None, allow_redirects=None):
         """ Send a HEAD request on the session object found using the
         given `alias`
 
@@ -286,17 +291,18 @@ class RequestsKeywords(object):
         """
 
         session = self._cache.switch(alias)
+        redir = False if allow_redirects is None else allow_redirects
         if cassette:
             with vcr.use_cassette(cassette, serializer='json', cassette_library_dir = 'cassettes/HEAD', record_mode='new_episodes', match_on=['url', 'method', 'headers', 'body']):
-                response = self.head_request(session, uri, headers)
+                response = self.head_request(session, uri, headers, redir)
         else:
-            response = self.head_request(session, uri, headers)
+            response = self.head_request(session, uri, headers, redir)
 
         return response
 
 
 
-    def options(self, alias, uri, headers=None, cassette=None):
+    def options(self, alias, uri, headers=None, cassette=None, allow_redirects=None):
         """ Send an OPTIONS request on the session object found using the
         given `alias`
 
@@ -309,52 +315,57 @@ class RequestsKeywords(object):
         """
 
         session = self._cache.switch(alias)
+        redir = True if allow_redirects is None else allow_redirects
         if cassette:
             with vcr.use_cassette(cassette, serializer='json', cassette_library_dir = 'cassettes/OPTIONS', record_mode='new_episodes', match_on=['url', 'method', 'headers', 'body']):
-                response = self.options_request(session, uri, headers)
+                response = self.options_request(session, uri, headers, redir)
         else:
-            response = self.options_request(session, uri, headers)
+            response = self.options_request(session, uri, headers, redir)
 
         return response
 
 
 
-    def get_request(self, session, uri, headers, params):
+    def get_request(self, session, uri, headers, params, allow_redirects):
         resp = session.get(self._get_url(session, uri),
                            headers=headers,
                            params=params,
-                           cookies=self.cookies, timeout=self.timeout)
+                           cookies=self.cookies, timeout=self.timeout,
+                           allow_redirects=allow_redirects)
 
         # store the last response object
         session.last_resp = resp
         return resp
 
-    def post_request(self, session, uri, data, headers, files):
+    def post_request(self, session, uri, data, headers, files, allow_redirects):
         resp = session.post(self._get_url(session, uri),
                             data=data, headers=headers,
                             files=files,
-                            cookies=self.cookies, timeout=self.timeout)
+                            cookies=self.cookies, timeout=self.timeout,
+                           allow_redirects=allow_redirects)
 
         # store the last response object
         session.last_resp = resp
         self.builtin.log("Post response: " + resp.content, 'DEBUG')
         return resp
 
-    def patch_request(self, session, uri, data, headers, files):
+    def patch_request(self, session, uri, data, headers, files, allow_redirects):
         resp = session.patch(self._get_url(session, uri),
                             data=data, headers=headers,
                             files=files,
-                            cookies=self.cookies, timeout=self.timeout)
+                            cookies=self.cookies, timeout=self.timeout,
+                           allow_redirects=allow_redirects)
 
         # store the last response object
         session.last_resp = resp
         self.builtin.log("Patch response: " + resp.content, 'DEBUG')
         return resp
 
-    def put_request(self, session, uri, data, headers):
+    def put_request(self, session, uri, data, headers, allow_redirects):
         resp = session.put(self._get_url(session, uri),
                            data=data, headers=headers,
-                           cookies=self.cookies, timeout=self.timeout)
+                           cookies=self.cookies, timeout=self.timeout,
+                           allow_redirects=allow_redirects)
 
         self.builtin.log("PUT response: %s DEBUG" % resp.content)
 
@@ -362,26 +373,29 @@ class RequestsKeywords(object):
         session.last_resp = resp
         return resp
 
-    def delete_request(self, session, uri, data, headers):
+    def delete_request(self, session, uri, data, headers, allow_redirects):
         resp = session.delete(self._get_url(session, uri), data=data,
                               headers=headers, cookies=self.cookies,
-                              timeout=self.timeout)
+                              timeout=self.timeout,
+                              allow_redirects=allow_redirects)
 
         # store the last response object
         session.last_resp = resp
         return resp
 
-    def head_request(self, session, uri, headers):
+    def head_request(self, session, uri, headers, allow_redirects):
         resp = session.head(self._get_url(session, uri), headers=headers,
-                            cookies=self.cookies, timeout=self.timeout)
+                            cookies=self.cookies, timeout=self.timeout,
+                            allow_redirects=allow_redirects)
 
         # store the last response object
         session.last_resp = resp
         return resp
 
-    def options_request(self, session, uri, headers):
+    def options_request(self, session, uri, headers, allow_redirects):
         resp = session.options(self._get_url(session, uri), headers=headers,
-                            cookies=self.cookies, timeout=self.timeout)
+                            cookies=self.cookies, timeout=self.timeout,
+                            allow_redirects=allow_redirects)
 
         # store the last response object
         session.last_resp = resp

--- a/tests/testcase.txt
+++ b/tests/testcase.txt
@@ -158,3 +158,86 @@ Patch Requests
     ${resp}=    Patch    httpbin    /patch    data=${data}    headers=${headers}
     Dictionary Should Contain Value    ${resp.json()['form']}    bulkan
     Dictionary Should Contain Value    ${resp.json()['form']}    evcimen
+
+Get Request With Redirection
+    [Tags]  get
+    Create Session  httpbin  http://httpbin.org
+
+    ${resp}=  Get  httpbin  /redirect/1
+    Should Be Equal As Strings  ${resp.status_code}  200
+
+    ${resp}=  Get  httpbin  /redirect/1  allow_redirects=${true}
+    Should Be Equal As Strings  ${resp.status_code}  200
+
+Get Request Without Redirection
+    [Tags]  get
+    Create Session  httpbin  http://httpbin.org
+
+    ${resp}=  Get  httpbin  /redirect/1  allow_redirects=${false}
+    ${status}=  Convert To String  ${resp.status_code}
+    Should Start With  ${status}  30
+
+Options Request With Redirection
+    [Tags]  options
+    Create Session  httpbin  http://httpbin.org
+
+    ${resp}=  Options  httpbin  /redirect/1
+    Should Be Equal As Strings  ${resp.status_code}  200
+
+    ${resp}=  Options  httpbin  /redirect/1  allow_redirects=${true}
+    Should Be Equal As Strings  ${resp.status_code}  200
+
+Head Request With Redirection
+    [Tags]  head
+    Create Session  httpbin  http://httpbin.org
+
+    ${resp}=  Head  httpbin  /redirect/1  allow_redirects=${true}
+    Should Be Equal As Strings  ${resp.status_code}  200
+
+Head Request Without Redirection
+    [Tags]  head
+    Create Session  httpbin  http://httpbin.org
+
+    ${resp}=  Head  httpbin  /redirect/1
+    ${status}=  Convert To String  ${resp.status_code}
+    Should Start With  ${status}  30
+
+    ${resp}=  Head  httpbin  /redirect/1  allow_redirects=${false}
+    ${status}=  Convert To String  ${resp.status_code}
+    Should Start With  ${status}  30
+
+Post Request With Redirection
+    [Tags]  post
+    Create Session  jigsaw  http://jigsaw.w3.org
+
+    ${resp}=  Post  jigsaw  /HTTP/300/302.html
+    Should Be Equal As Strings  ${resp.status_code}  200
+
+    ${resp}=  Post  jigsaw  /HTTP/300/302.html  allow_redirects=${true}
+    Should Be Equal As Strings  ${resp.status_code}  200
+
+Post Request Without Redirection
+    [Tags]  post
+    Create Session  jigsaw  http://jigsaw.w3.org
+
+    ${resp}=  Post  jigsaw  /HTTP/300/302.html  allow_redirects=${false}
+    ${status}=  Convert To String  ${resp.status_code}
+    Should Start With  ${status}  30
+
+Put Request With Redirection
+    [Tags]  put
+    Create Session  jigsaw  http://jigsaw.w3.org
+
+    ${resp}=  Put  jigsaw  /HTTP/300/302.html
+    Should Be Equal As Strings  ${resp.status_code}  200
+
+    ${resp}=  Put  jigsaw  /HTTP/300/302.html  allow_redirects=${true}
+    Should Be Equal As Strings  ${resp.status_code}  200
+
+Put Request Without Redirection
+    [Tags]  put
+    Create Session  jigsaw  http://jigsaw.w3.org
+
+    ${resp}=  Put  jigsaw  /HTTP/300/302.html  allow_redirects=${false}
+    ${status}=  Convert To String  ${resp.status_code}
+    Should Start With  ${status}  30


### PR DESCRIPTION
Additional parameter allow_redirect has been added to GET, PUT, POST,
PATCH, DELETE, OPTIONS and HEAD methods. Warning: default behavior for
HEAD method is allow_redirect=False.

Due to httpbin.org website limitations, no test cases have been
written for PATCH and DELETE methods, and the OPTIONS method is
tested with allow_redirect=True only.
