### PR TITLE
Keyword extension for JSON pretty printing and code cleanup

### DIFF
--- a/src/RequestsLibrary/RequestsKeywords.py
+++ b/src/RequestsLibrary/RequestsKeywords.py
@@ -139,6 +139,8 @@ class RequestsKeywords(object):
         """ Convert a string to a JSON object
 
         `content` String content to convert into JSON
+
+        'pretty_print' If defined, will output JSON is pretty print format
         """
         if pretty_print:
             json_ = self._json_pretty_print(content)
@@ -190,9 +192,9 @@ class RequestsKeywords(object):
         redir = True if allow_redirects is None else allow_redirects
         if cassette:
             with vcr.use_cassette(cassette, serializer='json', cassette_library_dir = 'cassettes/POST', record_mode='new_episodes', match_on=['url', 'method', 'headers', 'body']):
-                response = self.post_request(session, uri, data, headers, files, redir)
+                response = self._post_request(session, uri, data, headers, files, redir)
         else:
-            response = self.post_request(session, uri, data, headers, files, redir)
+            response = self._post_request(session, uri, data, headers, files, redir)
 
         return response
 
@@ -217,9 +219,9 @@ class RequestsKeywords(object):
         redir = True if allow_redirects is None else allow_redirects
         if cassette:
             with vcr.use_cassette(cassette, serializer='json', cassette_library_dir = 'cassettes/PATCH', record_mode='new_episodes', match_on=['url', 'method', 'headers', 'body']):
-                response = self.patch_request(session, uri, data, headers, files, redir)
+                response = self._patch_request(session, uri, data, headers, files, redir)
         else:
-            response = self.patch_request(session, uri, data, headers, files, redir)
+            response = self._patch_request(session, uri, data, headers, files, redir)
 
         return response
 
@@ -240,9 +242,9 @@ class RequestsKeywords(object):
         redir = True if allow_redirects is None else allow_redirects
         if cassette:
             with vcr.use_cassette(cassette, serializer='json', cassette_library_dir = 'cassettes/PUT', record_mode='new_episodes', match_on=['url', 'method', 'headers', 'body']):
-                response = self.put_request(session, uri, data, headers, redir)
+                response = self._put_request(session, uri, data, headers, redir)
         else:
-            response = self.put_request(session, uri, data, headers, redir)
+            response = self._put_request(session, uri, data, headers, redir)
 
         return response
 
@@ -265,9 +267,9 @@ class RequestsKeywords(object):
         redir = True if allow_redirects is None else allow_redirects
         if cassette:
             with vcr.use_cassette(cassette, serializer='json', cassette_library_dir = 'cassettes/DELETE', record_mode='new_episodes', match_on=['url', 'method', 'headers', 'body']):
-                response = self.delete_request(session, uri, data, headers, redir)
+                response = self._delete_request(session, uri, data, headers, redir)
         else:
-            response = self.delete_request(session, uri, data, headers, redir)
+            response = self._delete_request(session, uri, data, headers, redir)
 
         return response
 
@@ -289,9 +291,9 @@ class RequestsKeywords(object):
         redir = False if allow_redirects is None else allow_redirects
         if cassette:
             with vcr.use_cassette(cassette, serializer='json', cassette_library_dir = 'cassettes/HEAD', record_mode='new_episodes', match_on=['url', 'method', 'headers', 'body']):
-                response = self.head_request(session, uri, headers, redir)
+                response = self._head_request(session, uri, headers, redir)
         else:
-            response = self.head_request(session, uri, headers, redir)
+            response = self._head_request(session, uri, headers, redir)
 
         return response
 
@@ -313,9 +315,9 @@ class RequestsKeywords(object):
         redir = True if allow_redirects is None else allow_redirects
         if cassette:
             with vcr.use_cassette(cassette, serializer='json', cassette_library_dir = 'cassettes/OPTIONS', record_mode='new_episodes', match_on=['url', 'method', 'headers', 'body']):
-                response = self.options_request(session, uri, headers, redir)
+                response = self._options_request(session, uri, headers, redir)
         else:
-            response = self.options_request(session, uri, headers, redir)
+            response = self._options_request(session, uri, headers, redir)
 
         return response
 

--- a/tests/testcase.txt
+++ b/tests/testcase.txt
@@ -241,3 +241,35 @@ Put Request Without Redirection
     ${resp}=  Put  jigsaw  /HTTP/300/302.html  allow_redirects=${false}
     ${status}=  Convert To String  ${resp.status_code}
     Should Start With  ${status}  30
+
+Do Not Pretty Print a JSON object
+    [Tags]    json
+    Comment    Define json variable.
+    ${var}=   Create Dictionary   key_one   true     key_two     this is a test string
+    ${resp}=     Get  httpbin  /get    params=${var}
+    Set Suite Variable    ${resp}
+    Should Be Equal As Strings  ${resp.status_code}  200
+    Log    ${resp.content}
+    ${jsondata}=  To Json  ${resp.content}
+    Log    ${jsondata['args']}
+    Should Be Equal As Strings    ${jsondata['args']}    ${var}
+
+Pretty Print a JSON object
+    [Tags]    json
+    Comment    Define json variable.
+    Log    ${resp}
+    ${output}=    To Json    ${resp.content}    pretty_print=True
+    Log    ${output}
+    Should Contain    ${output}    "key_one": "true"
+    Should Contain    ${output}    "key_two": "this is a test string"
+    Should Not Contain    ${output}    {u'key_two': u'this is a test string', u'key_one': u'true'}
+
+Set Pretty Print to non-Boolean value
+    [Tags]    json
+    Comment    Define json variable.
+    Log    ${resp}
+    ${output}=    To Json    ${resp.content}    pretty_print="Hello"
+    Log    ${output}
+    Should Contain    ${output}    "key_one": "true"
+    Should Contain    ${output}    "key_two": "this is a test string"
+    Should Not Contain    ${output}    {u'key_two': u'this is a test string', u'key_one': u'true'}


### PR DESCRIPTION
Sorry to bundle all of this into one pull request.  This is my first foray into this type of thing and I didn't know better.

There are three main changes:
1) Added an parameter, pretty_print, to TO JSON that allows users the option to have the JSON returned in pretty print format.  The parameter defaults to FALSE (don't make the change).

2) I moved the function, _get_url, lower in the file, in order to group keywords and internal functions together.  This is a readability change.

3) Finally, I added the underscore, '_,' to the functions that looked to be the internal ones.  This way the HTML doc will not display them.
