### PR TITLE
Support sending arrays in query string and request body

### DIFF
--- a/src/RequestsLibrary/RequestsKeywords.py
+++ b/src/RequestsLibrary/RequestsKeywords.py
@@ -981,7 +981,7 @@ class RequestsKeywords(object):
             if self._is_string_type(v):
                 v = v.encode('utf-8')
             utf8_data[k] = v
-        return urlencode(utf8_data)
+        return urlencode(utf8_data, doseq=True)
 
     def _format_data_according_to_header(self, session, data, headers):
         # Merged headers are already case insensitive

--- a/tests/testcase.robot
+++ b/tests/testcase.robot
@@ -21,7 +21,8 @@ Get Requests
 Get Requests with Url Parameters
     [Tags]  get
     Create Session  httpbin     http://httpbin.org
-    &{params}=   Create Dictionary   key=value     key2=value2
+    @{foo}=      Create List  bar  baz
+    &{params}=   Create Dictionary   key=value     key2=value2    foo=${foo}
     ${resp}=     Get Request  httpbin  /get    params=${params}
     Should Be Equal As Strings  ${resp.status_code}  200
     ${jsondata}=  To Json  ${resp.content}
@@ -142,11 +143,13 @@ Put Request With No Dictionary
 Post Requests
     [Tags]  post
     Create Session  httpbin  http://httpbin.org
-    &{data}=  Create Dictionary  name=bulkan  surname=evcimen
+    @{foo}=  Create List  bar  baz
+    &{data}=  Create Dictionary  name=bulkan  surname=evcimen  foo=${foo}
     &{headers}=  Create Dictionary  Content-Type=application/x-www-form-urlencoded
     ${resp}=  Post Request  httpbin  /post  data=${data}  headers=${headers}
     Dictionary Should Contain Value  ${resp.json()['form']}  bulkan
     Dictionary Should Contain Value  ${resp.json()['form']}  evcimen
+    Dictionary Should Contain Value  ${resp.json()['form']}  ${foo}
 
 Post With Unicode Data
     [Tags]  post


### PR DESCRIPTION
Before, if an array `foo = ['bar', 'baz']` was passed to a request as part of the `params` or `data`, it would be encoded as `foo=%5Bbar,baz%5D`, which will be received by the server as the string `"['bar','baz']"'`. This fixes the URL encoding of the request so that the array will be passed as `foo=bar&foo=baz`.