### PR TITLE
Run workflow when a draft release is published

### DIFF
--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -2,7 +2,7 @@ name: Upload Python Package
 
 on:
   release:
-    types: [created]
+    types: [published]
 
 jobs:
   deploy:


### PR DESCRIPTION
With current configuration if a draft release is created and published later the workflow is  not triggered.