### PR TITLE
Better and correct request/response logging

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -1,9 +1,9 @@
 # This workflow will install Python dependencies, run tests and lint with a single version of Python
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
-name: Python application
+name: Python build
 
-on: [push, pull_request]
+on: push
 
 jobs:
   build:

--- a/atests/index.html
+++ b/atests/index.html
@@ -1,0 +1,266 @@
+<!DOCTYPE html>
+<!--[if IEMobile 7 ]> <html lang="it_IT" class="no-js iem7"> <![endif]-->
+<!--[if lt IE 7]> <html class="ie6 lt-ie10 lt-ie9 lt-ie8 lt-ie7 no-js" lang="it_IT"> <![endif]-->
+<!--[if IE 7]>    <html class="ie7 lt-ie10 lt-ie9 lt-ie8 no-js" lang="it_IT"> <![endif]-->
+<!--[if IE 8]>    <html class="ie8 lt-ie10 lt-ie9 no-js" lang="it_IT"> <![endif]-->
+<!--[if IE 9]>    <html class="ie9 lt-ie10 no-js" lang="it_IT"> <![endif]-->
+<!--[if (gte IE 9)|(gt IEMobile 7)|!(IEMobile)|!(IE)]><!--><html class="no-js" lang="it_IT"><!--<![endif]-->
+
+<head>
+	<meta http-equiv="X-UA-Compatible" content="IE=Edge" />
+<meta http-equiv="content-type" content="text/html; charset=UTF-8;charset=utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=1" />
+<meta name="HandheldFriendly" content="true"/>
+
+<link rel="canonical" href="https://duckduckgo.com/">
+
+<link rel="stylesheet" href="/s1890.css" type="text/css">
+
+<link rel="stylesheet" href="/o1890.css" type="text/css">
+
+
+
+<link rel="shortcut icon" href="/favicon.ico" type="image/x-icon"/>
+<link rel="apple-touch-icon" href="/assets/icons/meta/DDG-iOS-icon_60x60.png"/>
+<link rel="apple-touch-icon" sizes="76x76" href="/assets/icons/meta/DDG-iOS-icon_76x76.png"/>
+<link rel="apple-touch-icon" sizes="120x120" href="/assets/icons/meta/DDG-iOS-icon_120x120.png"/>
+<link rel="apple-touch-icon" sizes="152x152" href="/assets/icons/meta/DDG-iOS-icon_152x152.png"/>
+<link rel="image_src" href="/assets/icons/meta/DDG-icon_256x256.png"/>
+<link rel="manifest" href="/manifest.json"/>
+
+<meta name="twitter:card" content="summary">
+<meta name="twitter:site" value="@duckduckgo">
+
+<meta property="og:url" content="https://duckduckgo.com/" />
+<meta property="og:site_name" content="DuckDuckGo" />
+<meta property="og:image" content="https://duckduckgo.com/assets/logo_social-media.png">
+
+
+	<title>DuckDuckGo — La privacy semplificata.</title>
+<meta property="og:title" content="DuckDuckGo — La privacy semplificata." />
+
+
+<meta property="og:description" content="The Internet privacy company that empowers you to seamlessly take control of your personal information online, without any tradeoffs.">
+<meta name="description" content="The Internet privacy company that empowers you to seamlessly take control of your personal information online, without any tradeoffs.">
+
+
+</head>
+<body id="pg-index" class="page-index body--home">
+	<script type="text/javascript">
+var settings_js_version = "/s2475.js",
+    locale = "it_IT";
+</script>
+<script type="text/javascript" src="/lib/l113.js"></script>
+<script type="text/javascript" src="/locale/it_IT/duckduckgo39.js"></script>
+<script type="text/javascript" src="/util/u439.js"></script>
+<script type="text/javascript" src="/d2779.js"></script>
+
+
+
+<script type="text/javascript">
+    DDG.page = new DDG.Pages.Home();
+</script>
+
+
+
+	<div class="site-wrapper  site-wrapper--home  js-site-wrapper">
+
+
+			<div class="header-wrap--home  js-header-wrap">
+	<div class="header--aside js-header-aside"></div>
+</div>
+			<div id="" class="content-wrap--home">
+				<div id="content_homepage" class="content--home" style="visibility: hidden">
+					<div class="cw--c">
+								<div class="logo-wrap--home">
+			<a id="logo_homepage_link" class="logo_homepage" href="/about">
+				About DuckDuckGo
+				<span class="logo_homepage__tt">Duck it!</span>
+			</a>
+		</div>
+
+						<div class="search-wrap--home">
+									<form id="search_form_homepage" class="search  search--home  js-search-form" name="x" method="POST" action="/html">
+			<input id="search_form_input_homepage" class="search__input  js-search-input" type="text" autocomplete="off" name="q" tabindex="1" value="">
+			<input id="search_button_homepage" class="search__button  js-search-button" type="submit" tabindex="2" value="S" />
+			<input id="search_form_input_clear" class="search__clear  empty  js-search-clear" type="button" tabindex="3" value="X" />
+			<div id="search_elements_hidden" class="search__hidden  js-search-hidden"></div>
+		</form>
+
+						</div>
+
+
+
+						<!-- it_IT Tutte le Impostazioni -->
+<noscript>
+    <div class="tag-home">
+        <div class="tag-home__wrapper">
+            <div class="tag-home__item">
+                Il motore di ricerca che non ti traccia.
+                <span class="hide--screen-xs"><a href="/about" class="tag-home__link">Maggiori Informazioni</a>.</span>
+            </div>
+        </div>
+    </div>
+</noscript>
+<div class="tag-home  tag-home--slide  no-js__hide  js-tag-home"></div>
+        <div id="error_homepage"></div>
+
+
+
+
+					</div> <!-- cw -->
+				</div> <!-- content_homepage //-->
+			</div> <!-- content_wrapper_homepage //-->
+			<div id="footer_homepage" class="foot-home  js-foot-home"></div>
+
+<script type="text/javascript">
+	{function seterr(str) {
+		var error=document.getElementById('error_homepage');
+		error.innerHTML=str;
+		$(error).css('display','block');
+	}
+	var err=new RegExp('[\?\&]e=([^\&]+)');var errm=new Array();errm['2']='nessuna ricerca';errm['3']='ricerca troppo lunga';errm['4']='nessuna codifica per UTF\u002d8';errm['6']='troppi termini di ricerca';if (err.test(window.location.href)) seterr('Oops, '+(errm[RegExp.$1]?errm[RegExp.$1]:'c\u0027è stato un errore.')+' &nbsp;Riprova');};
+
+	if (kurl) {
+	  document.getElementById("logo_homepage_link").href += (document.getElementById("logo_homepage_link").href.indexOf('?')==-1 ? '?t=i' : '') + kurl;
+	}
+</script>
+
+
+
+	</div> <!-- site-wrapper -->
+</body>
+</html>
+<!DOCTYPE html>
+<!--[if IEMobile 7 ]> <html lang="it_IT" class="no-js iem7"> <![endif]-->
+<!--[if lt IE 7]> <html class="ie6 lt-ie10 lt-ie9 lt-ie8 lt-ie7 no-js" lang="it_IT"> <![endif]-->
+<!--[if IE 7]>    <html class="ie7 lt-ie10 lt-ie9 lt-ie8 no-js" lang="it_IT"> <![endif]-->
+<!--[if IE 8]>    <html class="ie8 lt-ie10 lt-ie9 no-js" lang="it_IT"> <![endif]-->
+<!--[if IE 9]>    <html class="ie9 lt-ie10 no-js" lang="it_IT"> <![endif]-->
+<!--[if (gte IE 9)|(gt IEMobile 7)|!(IEMobile)|!(IE)]><!--><html class="no-js" lang="it_IT"><!--<![endif]-->
+
+<head>
+	<meta http-equiv="X-UA-Compatible" content="IE=Edge" />
+<meta http-equiv="content-type" content="text/html; charset=UTF-8;charset=utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=1" />
+<meta name="HandheldFriendly" content="true"/>
+
+<link rel="canonical" href="https://duckduckgo.com/">
+
+<link rel="stylesheet" href="/s1890.css" type="text/css">
+
+<link rel="stylesheet" href="/o1890.css" type="text/css">
+
+
+
+<link rel="shortcut icon" href="/favicon.ico" type="image/x-icon"/>
+<link rel="apple-touch-icon" href="/assets/icons/meta/DDG-iOS-icon_60x60.png"/>
+<link rel="apple-touch-icon" sizes="76x76" href="/assets/icons/meta/DDG-iOS-icon_76x76.png"/>
+<link rel="apple-touch-icon" sizes="120x120" href="/assets/icons/meta/DDG-iOS-icon_120x120.png"/>
+<link rel="apple-touch-icon" sizes="152x152" href="/assets/icons/meta/DDG-iOS-icon_152x152.png"/>
+<link rel="image_src" href="/assets/icons/meta/DDG-icon_256x256.png"/>
+<link rel="manifest" href="/manifest.json"/>
+
+<meta name="twitter:card" content="summary">
+<meta name="twitter:site" value="@duckduckgo">
+
+<meta property="og:url" content="https://duckduckgo.com/" />
+<meta property="og:site_name" content="DuckDuckGo" />
+<meta property="og:image" content="https://duckduckgo.com/assets/logo_social-media.png">
+
+
+	<title>DuckDuckGo — La privacy semplificata.</title>
+<meta property="og:title" content="DuckDuckGo — La privacy semplificata." />
+
+
+<meta property="og:description" content="The Internet privacy company that empowers you to seamlessly take control of your personal information online, without any tradeoffs.">
+<meta name="description" content="The Internet privacy company that empowers you to seamlessly take control of your personal information online, without any tradeoffs.">
+
+
+</head>
+<body id="pg-index" class="page-index body--home">
+	<script type="text/javascript">
+var settings_js_version = "/s2475.js",
+    locale = "it_IT";
+</script>
+<script type="text/javascript" src="/lib/l113.js"></script>
+<script type="text/javascript" src="/locale/it_IT/duckduckgo39.js"></script>
+<script type="text/javascript" src="/util/u439.js"></script>
+<script type="text/javascript" src="/d2779.js"></script>
+
+
+
+<script type="text/javascript">
+    DDG.page = new DDG.Pages.Home();
+</script>
+
+
+
+	<div class="site-wrapper  site-wrapper--home  js-site-wrapper">
+
+
+			<div class="header-wrap--home  js-header-wrap">
+	<div class="header--aside js-header-aside"></div>
+</div>
+			<div id="" class="content-wrap--home">
+				<div id="content_homepage" class="content--home" style="visibility: hidden">
+					<div class="cw--c">
+								<div class="logo-wrap--home">
+			<a id="logo_homepage_link" class="logo_homepage" href="/about">
+				About DuckDuckGo
+				<span class="logo_homepage__tt">Duck it!</span>
+			</a>
+		</div>
+
+						<div class="search-wrap--home">
+									<form id="search_form_homepage" class="search  search--home  js-search-form" name="x" method="POST" action="/html">
+			<input id="search_form_input_homepage" class="search__input  js-search-input" type="text" autocomplete="off" name="q" tabindex="1" value="">
+			<input id="search_button_homepage" class="search__button  js-search-button" type="submit" tabindex="2" value="S" />
+			<input id="search_form_input_clear" class="search__clear  empty  js-search-clear" type="button" tabindex="3" value="X" />
+			<div id="search_elements_hidden" class="search__hidden  js-search-hidden"></div>
+		</form>
+
+						</div>
+
+
+
+						<!-- it_IT Tutte le Impostazioni -->
+<noscript>
+    <div class="tag-home">
+        <div class="tag-home__wrapper">
+            <div class="tag-home__item">
+                Il motore di ricerca che non ti traccia.
+                <span class="hide--screen-xs"><a href="/about" class="tag-home__link">Maggiori Informazioni</a>.</span>
+            </div>
+        </div>
+    </div>
+</noscript>
+<div class="tag-home  tag-home--slide  no-js__hide  js-tag-home"></div>
+        <div id="error_homepage"></div>
+
+
+
+
+					</div> <!-- cw -->
+				</div> <!-- content_homepage //-->
+			</div> <!-- content_wrapper_homepage //-->
+			<div id="footer_homepage" class="foot-home  js-foot-home"></div>
+
+<script type="text/javascript">
+	{function seterr(str) {
+		var error=document.getElementById('error_homepage');
+		error.innerHTML=str;
+		$(error).css('display','block');
+	}
+	var err=new RegExp('[\?\&]e=([^\&]+)');var errm=new Array();errm['2']='nessuna ricerca';errm['3']='ricerca troppo lunga';errm['4']='nessuna codifica per UTF\u002d8';errm['6']='troppi termini di ricerca';if (err.test(window.location.href)) seterr('Oops, '+(errm[RegExp.$1]?errm[RegExp.$1]:'c\u0027è stato un errore.')+' &nbsp;Riprova');};
+
+	if (kurl) {
+	  document.getElementById("logo_homepage_link").href += (document.getElementById("logo_homepage_link").href.indexOf('?')==-1 ? '?t=i' : '') + kurl;
+	}
+</script>
+
+
+
+	</div> <!-- site-wrapper -->
+</body>
+</html>

--- a/atests/res_setup.robot
+++ b/atests/res_setup.robot
@@ -1,5 +1,6 @@
 *** Settings ***
 Library  Process
+Library  ../src/RequestsLibrary/RequestsKeywords.py
 
 
 *** Variables ***

--- a/atests/test_redirect.robot
+++ b/atests/test_redirect.robot
@@ -51,18 +51,18 @@ Post Request With Redirection
     # FIXME should be 2 different tests
     # FIXME should be verifed also the payload is returned
     # FIXME returned http method should be verified
-    ${resp}=  Post Request  ${GLOBAL_LOCAL_SESSION}  /redirect-to?url=anything
+    ${resp}=  Post Request  ${GLOBAL_LOCAL_SESSION}  /redirect-to?url=anything  data=something
     Status Should be  OK  ${resp}
     ${redirected_url}=  Catenate  ${HTTP_LOCAL_SERVER}/anything
     Should Be Equal As Strings  ${resp.json()['url']}  ${redirected_url}
-    ${resp}=  Post Request  ${GLOBAL_LOCAL_SESSION}  /redirect-to?url=anything  allow_redirects=${true}
+    ${resp}=  Post Request  ${GLOBAL_LOCAL_SESSION}  /redirect-to?url=anything  data=something  allow_redirects=${true}
     Status Should be  OK  ${resp}
     ${redirected_url}=  Catenate  ${HTTP_LOCAL_SERVER}/anything
     Should Be Equal As Strings  ${resp.json()['url']}  ${redirected_url}
 
 Post Request Without Redirection
     [Tags]  post
-    ${resp}=  Post Request  ${GLOBAL_LOCAL_SESSION}  /redirect-to?url=anything  allow_redirects=${false}
+    ${resp}=  Post Request  ${GLOBAL_LOCAL_SESSION}  /redirect-to?url=anything  data=something  allow_redirects=${false}
     Status Should be  302  ${resp}
 
 Put Request With Redirection

--- a/atests/testcase.robot
+++ b/atests/testcase.robot
@@ -338,3 +338,9 @@ Verify a non existing session
     [Tags]    session
     ${exists}=          Session Exists    non-existing-session
     Should Not Be True  ${exists}
+
+Post Request With Large Truncated Body
+    [Tags]  post
+    ${html}=  Get File  ${CURDIR}${/}index.html
+    ${resp}=  Post Request  ${GLOBAL_LOCAL_SESSION}  /anything  data=${html}
+    Status Should be  200  ${resp}

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,15 @@
 #!/usr/bin/env python
 
+import sys
 from os.path import abspath, dirname, join
 
 try:
     from setuptools import setup
 except ImportError:
     from distutils.core import setup
+
+
+PY3 = sys.version_info > (3,)
 
 VERSION = None
 version_file = join(dirname(abspath(__file__)), 'src', 'RequestsLibrary', 'version.py')
@@ -24,6 +28,9 @@ Operating System :: OS Independent
 Programming Language :: Python
 Topic :: Software Development :: Testing
 """[1:-1]
+
+TEST_REQUIRE = ['pytest', 'flask', 'coverage', 'flake8'] if PY3 \
+    else ['pytest', 'flask', 'coverage', 'flake8', 'mock']
 
 setup(name='robotframework-requests',
       version=VERSION,
@@ -45,5 +52,5 @@ setup(name='robotframework-requests',
           'requests'
       ],
       extras_require={
-          'test': ['pytest', 'flask', 'coverage', 'flake8']
+          'test': TEST_REQUIRE
       })

--- a/src/RequestsLibrary/RequestsKeywords.py
+++ b/src/RequestsLibrary/RequestsKeywords.py
@@ -932,14 +932,9 @@ class RequestsKeywords(object):
             uri,
             **kwargs):
 
-        # TODO this won't log the real headers that have been added by requests itself
-        # it should be moved after the real request to log those.
-        # But at the same time in case of failure debug information are not logged.
-        # (maybe it should be analysed)
-        log.log_request(method, session, uri, **kwargs)
         method_function = getattr(session, method)
-
         self._capture_output()
+
         resp = method_function(
             self._get_url(session, uri),
             params=utils.utf8_urlencode(kwargs.pop('params', None)),
@@ -947,8 +942,9 @@ class RequestsKeywords(object):
             cookies=self.cookies,
             verify=self.verify,
             **kwargs)
-        self._print_debug()
 
+        log.log_request(resp.request)
+        self._print_debug()
         session.last_resp = resp
         log.log_response(method, resp)
 

--- a/src/RequestsLibrary/RequestsKeywords.py
+++ b/src/RequestsLibrary/RequestsKeywords.py
@@ -943,10 +943,10 @@ class RequestsKeywords(object):
             verify=self.verify,
             **kwargs)
 
-        log.log_request(resp.request)
+        log.log_request(resp)
         self._print_debug()
         session.last_resp = resp
-        log.log_response(method, resp)
+        log.log_response(resp)
 
         data = kwargs.get('data', None)
         if is_file_descriptor(data):

--- a/src/RequestsLibrary/RequestsKeywords.py
+++ b/src/RequestsLibrary/RequestsKeywords.py
@@ -1,7 +1,6 @@
 import json
 import copy
 import sys
-import io
 
 import requests
 from requests.models import Response
@@ -18,6 +17,7 @@ from robot.utils.asserts import assert_equal
 from RequestsLibrary import utils, log
 from RequestsLibrary.compat import httplib, PY3
 from RequestsLibrary.exceptions import InvalidResponse
+from RequestsLibrary.utils import is_file_descriptor
 
 
 try:
@@ -686,9 +686,6 @@ class RequestsKeywords(object):
             allow_redirects=redir,
             timeout=timeout)
 
-        if isinstance(data, io.IOBase):
-            data.close()
-
         return response
 
     def patch_request(
@@ -954,6 +951,10 @@ class RequestsKeywords(object):
 
         session.last_resp = resp
         log.log_response(method, resp)
+
+        data = kwargs.get('data', None)
+        if is_file_descriptor(data):
+            data.close()
 
         return resp
 

--- a/src/RequestsLibrary/compat.py
+++ b/src/RequestsLibrary/compat.py
@@ -3,8 +3,8 @@ import sys
 PY3 = sys.version_info > (3,)
 
 if PY3:
-    import http.client as httplib
-    from urllib.parse import urlencode
+    import http.client as httplib  # noqa
+    from urllib.parse import urlencode  # noqa
 else:
-    import httplib
-    from urllib import urlencode
+    import httplib  # noqa
+    from urllib import urlencode  # noqa

--- a/src/RequestsLibrary/log.py
+++ b/src/RequestsLibrary/log.py
@@ -48,12 +48,11 @@ def log_request(
 def format_data_to_log_string_according_to_headers(session, data, headers):
     data_str = None
 
-    # when data is an open file descriptor we ignore it
-    if is_file_descriptor(data):
-        return data_str
-
     # Merged headers are already case insensitive
     headers = merge_headers(session, headers)
+
+    if is_file_descriptor(data):
+        return repr(data)
 
     if data is not None and headers is not None and 'Content-Type' in headers:
         if (headers['Content-Type'].find("application/json") != -1) or \

--- a/src/RequestsLibrary/log.py
+++ b/src/RequestsLibrary/log.py
@@ -2,7 +2,7 @@ import io
 
 from robot.api import logger
 
-from RequestsLibrary.utils import merge_headers
+from RequestsLibrary.utils import merge_headers, is_file_descriptor
 
 
 def log_response(method, response):
@@ -49,7 +49,7 @@ def format_data_to_log_string_according_to_headers(session, data, headers):
     data_str = None
 
     # when data is an open file descriptor we ignore it
-    if data and isinstance(data, io.IOBase):
+    if is_file_descriptor(data):
         return data_str
 
     # Merged headers are already case insensitive

--- a/src/RequestsLibrary/log.py
+++ b/src/RequestsLibrary/log.py
@@ -1,15 +1,18 @@
+import logging
+
+from RequestsLibrary.utils import is_file_descriptor
 from robot.api import logger
 
-from RequestsLibrary.utils import merge_headers, is_file_descriptor
+
+LOG_CHAR_LIMIT = 10000
 
 
 def log_response(response):
-    # TODO big responses should be truncated to avoid huge logs
-    logger.debug("%s Response : url=%s \n " % (response.request.method.upper(),
-                                               response.url) +
-                 "status=%s, reason=%s \n " % (response.status_code,
-                                               response.reason) +
-                 "body=%s \n " % response.text)
+    logger.info("%s Response : url=%s \n " % (response.request.method.upper(),
+                                              response.url) +
+                "status=%s, reason=%s \n " % (response.status_code,
+                                              response.reason) +
+                "body=%s \n " % format_data_to_log_string(response.text))
 
 
 def log_request(response):
@@ -20,15 +23,14 @@ def log_request(response):
     else:
         original_request = request
         redirected = ''
-    logger.info("%s Request : " % request.method.upper() +
+    logger.info("%s Request : " % original_request.method.upper() +
                 "url=%s %s\n " % (original_request.url, redirected) +
                 "path_url=%s \n " % original_request.path_url +
-                "headers=%s \n " % request.headers +
-                "body=%s \n " % request.body)
+                "headers=%s \n " % original_request.headers +
+                "body=%s \n " % format_data_to_log_string(original_request.body))
 
 
-# TODO Currently unused
-def format_data_to_log_string(data):
+def format_data_to_log_string(data, limit=LOG_CHAR_LIMIT):
 
     if not data:
         return None
@@ -36,6 +38,9 @@ def format_data_to_log_string(data):
     if is_file_descriptor(data):
         return repr(data)
 
-    return repr(data)
+    if len(data) > limit and logging.getLogger().level > 10:
+        data = "%s... (set the log level to DEBUG or TRACE to see the full content)" % data[:limit]
+
+    return data
 
 

--- a/src/RequestsLibrary/log.py
+++ b/src/RequestsLibrary/log.py
@@ -3,51 +3,31 @@ from robot.api import logger
 from RequestsLibrary.utils import merge_headers, is_file_descriptor
 
 
-def log_response(method, response):
+def log_response(response):
     # TODO big responses should be truncated to avoid huge logs
-    logger.debug('%s Response : status=%s, reason=%s\n' % (method.upper(),
-                                                           response.status_code,
-                                                           response.reason) +
-                 response.text)
+    logger.debug("%s Response : url=%s \n " % (response.request.method.upper(),
+                                               response.url) +
+                 "status=%s, reason=%s \n " % (response.status_code,
+                                               response.reason) +
+                 "body=%s \n " % response.text)
 
 
-def log_request2(
-        method,
-        session,
-        uri,
-        **kwargs):
-
-    # TODO would be nice to add also the alias
-    # TODO would be nice to pretty format the headers / json / data
-    # TODO big requests should be truncated to avoid huge logs
-
-    # kwargs might include: method, session, uri, params, files, headers,
-    #                       data, json, allow_redirects, timeout
-    args = kwargs.copy()
-    args.pop('session', None)
-    # This will log specific headers merged with session defined headers
-    merged_headers = merge_headers(session, args.pop('headers', None))
-    formatted_data = format_data_to_log_string(args.pop('data', None))
-    formatted_json = args.pop('json', None)
-    method_log = '%s Request using : ' % method.upper()
-    uri_log = 'uri=%s' % uri
-    composed_log = method_log + uri_log
-    for arg in args:
-        composed_log += ', %s=%s' % (arg, kwargs.get(arg, None))
-    logger.info(composed_log + '\n' +
-                'headers=%s \n' % merged_headers +
-                'data=%s \n' % formatted_data +
-                'json=%s' % formatted_json)
-
-
-def log_request(request):
+def log_request(response):
+    request = response.request
+    if response.history:
+        original_request = response.history[0].request
+        redirected = '(redirected) '
+    else:
+        original_request = request
+        redirected = ''
     logger.info("%s Request : " % request.method.upper() +
-                "url=%s \n " % request.url +
-                "path_url=%s \n " % request.path_url +
+                "url=%s %s\n " % (original_request.url, redirected) +
+                "path_url=%s \n " % original_request.path_url +
                 "headers=%s \n " % request.headers +
                 "body=%s \n " % request.body)
 
 
+# TODO Currently unused
 def format_data_to_log_string(data):
 
     if not data:

--- a/src/RequestsLibrary/log.py
+++ b/src/RequestsLibrary/log.py
@@ -41,7 +41,7 @@ def log_request2(
 
 
 def log_request(request):
-    logger.info("%s Request : " % request.method +
+    logger.info("%s Request : " % request.method.upper() +
                 "url=%s \n " % request.url +
                 "path_url=%s \n " % request.path_url +
                 "headers=%s \n " % request.headers +

--- a/src/RequestsLibrary/log.py
+++ b/src/RequestsLibrary/log.py
@@ -1,5 +1,3 @@
-import io
-
 from robot.api import logger
 
 from RequestsLibrary.utils import merge_headers, is_file_descriptor
@@ -13,7 +11,7 @@ def log_response(method, response):
                  response.text)
 
 
-def log_request(
+def log_request2(
         method,
         session,
         uri,
@@ -40,6 +38,14 @@ def log_request(
                 'headers=%s \n' % merged_headers +
                 'data=%s \n' % formatted_data +
                 'json=%s' % formatted_json)
+
+
+def log_request(request):
+    logger.info("%s Request : " % request.method +
+                "url=%s \n " % request.url +
+                "path_url=%s \n " % request.path_url +
+                "headers=%s \n " % request.headers +
+                "body=%s \n " % request.body)
 
 
 def format_data_to_log_string(data):

--- a/src/RequestsLibrary/log.py
+++ b/src/RequestsLibrary/log.py
@@ -42,5 +42,3 @@ def format_data_to_log_string(data, limit=LOG_CHAR_LIMIT):
         data = "%s... (set the log level to DEBUG or TRACE to see the full content)" % data[:limit]
 
     return data
-
-

--- a/src/RequestsLibrary/log.py
+++ b/src/RequestsLibrary/log.py
@@ -21,7 +21,6 @@ def log_request(
 
     # TODO would be nice to add also the alias
     # TODO would be nice to pretty format the headers / json / data
-    # TODO move in common the data formatting to have this as @staticmethod
     # TODO big requests should be truncated to avoid huge logs
 
     # kwargs might include: method, session, uri, params, files, headers,
@@ -30,9 +29,7 @@ def log_request(
     args.pop('session', None)
     # This will log specific headers merged with session defined headers
     merged_headers = merge_headers(session, args.pop('headers', None))
-    formatted_data = format_data_to_log_string_according_to_headers(session,
-                                                                    args.pop('data', None),
-                                                                    merged_headers)
+    formatted_data = format_data_to_log_string(args.pop('data', None))
     formatted_json = args.pop('json', None)
     method_log = '%s Request using : ' % method.upper()
     uri_log = 'uri=%s' % uri
@@ -45,23 +42,14 @@ def log_request(
                 'json=%s' % formatted_json)
 
 
-def format_data_to_log_string_according_to_headers(session, data, headers):
-    data_str = None
+def format_data_to_log_string(data):
 
-    # Merged headers are already case insensitive
-    headers = merge_headers(session, headers)
+    if not data:
+        return None
 
     if is_file_descriptor(data):
         return repr(data)
 
-    if data is not None and headers is not None and 'Content-Type' in headers:
-        if (headers['Content-Type'].find("application/json") != -1) or \
-                (headers['Content-Type'].find("application/x-www-form-urlencoded") != -1):
-            if isinstance(data, bytes):
-                data_str = data.decode('utf-8')
-            else:
-                data_str = data
-        else:
-            data_str = "<" + headers['Content-Type'] + ">"
+    return repr(data)
 
-    return data_str
+

--- a/src/RequestsLibrary/utils.py
+++ b/src/RequestsLibrary/utils.py
@@ -30,7 +30,7 @@ def merge_headers(session, headers):
         # have priority and can override values
         merged_headers = session.headers.copy()
 
-    # Make sure merged_headers are CaseIsensitiveDict
+    # Make sure merged_headers are CaseInsensitiveDict
     if not isinstance(merged_headers, CaseInsensitiveDict):
         merged_headers = CaseInsensitiveDict(merged_headers)
 

--- a/src/RequestsLibrary/utils.py
+++ b/src/RequestsLibrary/utils.py
@@ -70,6 +70,14 @@ def is_string_type(data):
     return False
 
 
+def is_file_descriptor(fd):
+    if PY3 and isinstance(fd, io.IOBase):
+        return True
+    if not PY3 and isinstance(fd, file): # noqa
+        return True
+    return False
+
+
 def utf8_urlencode(data):
     if is_string_type(data):
         return data.encode('utf-8')
@@ -87,7 +95,7 @@ def utf8_urlencode(data):
 
 def format_data_according_to_header(session, data, headers):
     # when data is an open file descriptor we ignore it
-    if isinstance(data, io.IOBase):
+    if is_file_descriptor(data):
         return data
 
     # Merged headers are already case insensitive

--- a/src/RequestsLibrary/version.py
+++ b/src/RequestsLibrary/version.py
@@ -1,1 +1,1 @@
-VERSION = '0.7.0'
+VERSION = '0.7b1'

--- a/utests/__init__.py
+++ b/utests/__init__.py
@@ -9,4 +9,3 @@ if PY3:
     from unittest import mock  # noqa
 else:
     import mock  # noqa
-

--- a/utests/__init__.py
+++ b/utests/__init__.py
@@ -1,0 +1,12 @@
+import os
+import sys
+
+
+PY3 = sys.version_info > (3,)
+SCRIPT_DIR = os.path.dirname(__file__)
+
+if PY3:
+    from unittest import mock  # noqa
+else:
+    import mock  # noqa
+

--- a/utests/test_RequestKeywords.py
+++ b/utests/test_RequestKeywords.py
@@ -1,6 +1,6 @@
 import os
 
-from utests.mock import MagicMock
+from utests import mock
 
 from RequestsLibrary import RequestsKeywords
 from utests import SCRIPT_DIR
@@ -10,7 +10,7 @@ def test_common_request_file_descriptor_closing():
     keywords = RequestsKeywords()
     session = keywords.create_session('alias', 'http://mocking.rules')
     # this prevents a real network call from being executed
-    session.get = MagicMock()
+    session.get = mock.MagicMock()
     with open(os.path.join(SCRIPT_DIR, '../atests/randombytes.bin'), 'rb') as f:
         keywords._common_request('get', session,
                                  'http://mocking.rules', data=f)

--- a/utests/test_RequestKeywords.py
+++ b/utests/test_RequestKeywords.py
@@ -1,0 +1,17 @@
+import os
+
+from utests.mock import MagicMock
+
+from RequestsLibrary import RequestsKeywords
+from utests import SCRIPT_DIR
+
+
+def test_common_request_file_descriptor_closing():
+    keywords = RequestsKeywords()
+    session = keywords.create_session('alias', 'http://mocking.rules')
+    # this prevents a real network call from being executed
+    session.get = MagicMock()
+    with open(os.path.join(SCRIPT_DIR, '../atests/randombytes.bin'), 'rb') as f:
+        keywords._common_request('get', session,
+                                 'http://mocking.rules', data=f)
+        assert f.closed is True

--- a/utests/test_log.py
+++ b/utests/test_log.py
@@ -4,82 +4,44 @@ import os
 from requests import Session
 from requests.utils import default_headers
 
-from RequestsLibrary.log import format_data_to_log_string_according_to_headers
+from RequestsLibrary.log import format_data_to_log_string
 
 
 SCRIPT_DIR = os.path.dirname(__file__)
 
 
 def test_format_with_data_and_headers_none():
-    session = Session()
-    data_str = format_data_to_log_string_according_to_headers(session, None, None)
+    data_str = format_data_to_log_string(None)
     assert data_str is None
 
 
-def test_format_with_headers_none():
-    session = Session()
-    data_str = format_data_to_log_string_according_to_headers(session, 'data', None)
-    # TODO i think this is not the best thing
-    assert data_str is None
-
-
-def test_format_with_data_none():
-    session = Session()
-    data_str = format_data_to_log_string_according_to_headers(session, None, default_headers())
-    assert data_str is None
-
-
-def test_format_with_header_json_and_data_none():
-    session = Session()
-    headers = default_headers()
-    headers['Content-Type'] = "application/json"
-    data_str = format_data_to_log_string_according_to_headers(session, None, headers)
-    assert data_str is None
-
-
-def test_format_with_header_json_and_data_json():
-    session = Session()
-    headers = default_headers()
-    headers['Content-Type'] = "application/json"
+def test_format_with_data_json():
     data = json.dumps({'key': 'value'})
-    data_str = format_data_to_log_string_according_to_headers(session, data, headers)
-    assert data_str == data
+    data_str = format_data_to_log_string(data)
+    assert data_str == repr(data)
 
 
-def test_format_with_wrong_header_and_data_json():
-    session = Session()
-    headers = default_headers()
-    headers['Misspelled'] = "text/xml"
+def test_format_with_data_string():
     data = "<xml>text</xml>"
-    data_str = format_data_to_log_string_according_to_headers(session, data, headers)
-    # TODO this should change
-    assert data_str is None
+    data_str = format_data_to_log_string(data)
+    assert data_str == repr(data)
 
 
 def test_format_with_binary_data():
-    session = Session()
-    headers = default_headers()
-    headers['Content-Type'] = "application/octet-stream"
     with open(os.path.join(SCRIPT_DIR, '../atests/randombytes.bin'), 'rb') as f:
         data = f.read()
-    data_str = format_data_to_log_string_according_to_headers(session, data, headers)
-    assert data_str == "<application/octet-stream>"
+    data_str = format_data_to_log_string(data)
+    assert data_str == repr(data)
 
 
 def test_format_with_utf_encoded_data():
-    session = Session()
-    headers = default_headers()
-    headers['Content-Type'] = "application/json"
     with open(os.path.join(SCRIPT_DIR, '../atests/data.json'), 'rb') as f:
         data = f.read()
-    data_str = format_data_to_log_string_according_to_headers(session, data, headers)
-    assert data_str.encode('utf-8') == data
+    data_str = format_data_to_log_string(data)
+    assert data_str == repr(data)
 
 
 def test_format_with_file_descriptor():
-    session = Session()
-    headers = default_headers()
-    headers['Content-Type'] = "application/octet-stream"
     with open(os.path.join(SCRIPT_DIR, '../atests/randombytes.bin'), 'rb') as f:
-        data_str = format_data_to_log_string_according_to_headers(session, f, headers)
+        data_str = format_data_to_log_string(f)
     assert data_str == repr(f)

--- a/utests/test_log.py
+++ b/utests/test_log.py
@@ -82,4 +82,4 @@ def test_format_with_file_descriptor():
     headers['Content-Type'] = "application/octet-stream"
     with open(os.path.join(SCRIPT_DIR, '../atests/randombytes.bin'), 'rb') as f:
         data_str = format_data_to_log_string_according_to_headers(session, f, headers)
-    assert data_str is None
+    assert data_str == repr(f)

--- a/utests/test_log.py
+++ b/utests/test_log.py
@@ -1,29 +1,35 @@
 import json
+import os
+
 from requests import Session
 from requests.utils import default_headers
+
 from RequestsLibrary.log import format_data_to_log_string_according_to_headers
 
 
-def test_format_data_with_data_and_headers_none():
+SCRIPT_DIR = os.path.dirname(__file__)
+
+
+def test_format_with_data_and_headers_none():
     session = Session()
     data_str = format_data_to_log_string_according_to_headers(session, None, None)
     assert data_str is None
 
 
-def test_format_data_with_headers_none():
+def test_format_with_headers_none():
     session = Session()
     data_str = format_data_to_log_string_according_to_headers(session, 'data', None)
     # TODO i think this is not the best thing
     assert data_str is None
 
 
-def test_format_data_with_data_none():
+def test_format_with_data_none():
     session = Session()
     data_str = format_data_to_log_string_according_to_headers(session, None, default_headers())
     assert data_str is None
 
 
-def test_format_data_with_header_json_and_data_none():
+def test_format_with_header_json_and_data_none():
     session = Session()
     headers = default_headers()
     headers['Content-Type'] = "application/json"
@@ -31,16 +37,16 @@ def test_format_data_with_header_json_and_data_none():
     assert data_str is None
 
 
-def test_format_data_with_header_json_and_data_json():
+def test_format_with_header_json_and_data_json():
     session = Session()
     headers = default_headers()
     headers['Content-Type'] = "application/json"
     data = json.dumps({'key': 'value'})
     data_str = format_data_to_log_string_according_to_headers(session, data, headers)
-    assert data_str is data
+    assert data_str == data
 
 
-def test_format_data_with_wrong_header_and_data_json():
+def test_format_with_wrong_header_and_data_json():
     session = Session()
     headers = default_headers()
     headers['Misspelled'] = "text/xml"
@@ -49,3 +55,31 @@ def test_format_data_with_wrong_header_and_data_json():
     # TODO this should change
     assert data_str is None
 
+
+def test_format_with_binary_data():
+    session = Session()
+    headers = default_headers()
+    headers['Content-Type'] = "application/octet-stream"
+    with open(os.path.join(SCRIPT_DIR, '../atests/randombytes.bin'), 'rb') as f:
+        data = f.read()
+    data_str = format_data_to_log_string_according_to_headers(session, data, headers)
+    assert data_str == "<application/octet-stream>"
+
+
+def test_format_with_utf_encoded_data():
+    session = Session()
+    headers = default_headers()
+    headers['Content-Type'] = "application/json"
+    with open(os.path.join(SCRIPT_DIR, '../atests/data.json'), 'rb') as f:
+        data = f.read()
+    data_str = format_data_to_log_string_according_to_headers(session, data, headers)
+    assert data_str.encode('utf-8') == data
+
+
+def test_format_with_file_descriptor():
+    session = Session()
+    headers = default_headers()
+    headers['Content-Type'] = "application/octet-stream"
+    with open(os.path.join(SCRIPT_DIR, '../atests/randombytes.bin'), 'rb') as f:
+        data_str = format_data_to_log_string_according_to_headers(session, f, headers)
+    assert data_str is None

--- a/utests/test_log.py
+++ b/utests/test_log.py
@@ -1,3 +1,4 @@
+import json
 from requests import Session
 from requests.utils import default_headers
 from RequestsLibrary.log import format_data_to_log_string_according_to_headers
@@ -5,25 +6,46 @@ from RequestsLibrary.log import format_data_to_log_string_according_to_headers
 
 def test_format_data_with_data_and_headers_none():
     session = Session()
-    data = format_data_to_log_string_according_to_headers(session, None, None)
-    assert data is None
+    data_str = format_data_to_log_string_according_to_headers(session, None, None)
+    assert data_str is None
 
 
 def test_format_data_with_headers_none():
     session = Session()
-    data = format_data_to_log_string_according_to_headers(session, 'data', None)
-    assert data is None
+    data_str = format_data_to_log_string_according_to_headers(session, 'data', None)
+    # TODO i think this is not the best thing
+    assert data_str is None
 
 
 def test_format_data_with_data_none():
     session = Session()
-    data = format_data_to_log_string_according_to_headers(session, None, default_headers())
-    assert data is None
+    data_str = format_data_to_log_string_according_to_headers(session, None, default_headers())
+    assert data_str is None
 
 
 def test_format_data_with_header_json_and_data_none():
     session = Session()
     headers = default_headers()
     headers['Content-Type'] = "application/json"
-    data = format_data_to_log_string_according_to_headers(session, None, headers)
-    assert data is None
+    data_str = format_data_to_log_string_according_to_headers(session, None, headers)
+    assert data_str is None
+
+
+def test_format_data_with_header_json_and_data_json():
+    session = Session()
+    headers = default_headers()
+    headers['Content-Type'] = "application/json"
+    data = json.dumps({'key': 'value'})
+    data_str = format_data_to_log_string_according_to_headers(session, data, headers)
+    assert data_str is data
+
+
+def test_format_data_with_wrong_header_and_data_json():
+    session = Session()
+    headers = default_headers()
+    headers['Misspelled'] = "text/xml"
+    data = "<xml>text</xml>"
+    data_str = format_data_to_log_string_according_to_headers(session, data, headers)
+    # TODO this should change
+    assert data_str is None
+

--- a/utests/test_log.py
+++ b/utests/test_log.py
@@ -42,7 +42,7 @@ def test_format_with_utf_encoded_data():
 def test_format_with_file_descriptor():
     with open(os.path.join(SCRIPT_DIR, '../atests/randombytes.bin'), 'rb') as f:
         data_str = format_data_to_log_string(f)
-    assert data_str == repr(f)
+        assert data_str == repr(f)
 
 
 @mock.patch('RequestsLibrary.log.logger')

--- a/utests/test_log.py
+++ b/utests/test_log.py
@@ -89,10 +89,10 @@ def test_log_response(mocked_logger):
     response.text = "<html>body</html>"
     log_response(response)
     assert mocked_logger.info.call_args[0][0] == ("%s Response : url=%s \n " % (response.request.method.upper(),
-                                                                                 response.url) +
-                                                   "status=%s, reason=%s \n " % (response.status_code,
-                                                                                 response.reason) +
-                                                   "body=%s \n " % response.text)
+                                                                                response.url) +
+                                                  "status=%s, reason=%s \n " % (response.status_code,
+                                                                                response.reason) +
+                                                  "body=%s \n " % response.text)
 
 
 def test_format_data_to_log_string_truncated_1():

--- a/utests/test_log.py
+++ b/utests/test_log.py
@@ -3,7 +3,7 @@ import os
 
 from requests import Request
 
-from RequestsLibrary.log import format_data_to_log_string, log_request
+from RequestsLibrary.log import format_data_to_log_string, log_request, log_response
 from utests import SCRIPT_DIR
 from utests import mock
 
@@ -49,10 +49,51 @@ def test_format_with_file_descriptor():
 def test_log_request(mocked_logger):
     request = Request(method='get', url='http://mock.rulezz')
     request = request.prepare()
-    log_request(request)
+    response = mock.MagicMock()
+    response.history = []
+    response.request = request
+    log_request(response)
     assert mocked_logger.info.call_args[0][0] == ("%s Request : " % request.method +
                                                   "url=%s \n " % request.url +
                                                   "path_url=%s \n " % request.path_url +
                                                   "headers=%s \n " % request.headers +
                                                   "body=%s \n " % request.body)
 
+
+@mock.patch('RequestsLibrary.log.logger')
+def test_log_request_with_redirect(mocked_logger):
+    request = Request(method='get', url='http://mock.rulezz/redirected')
+    request = request.prepare()
+    original = Request(method='get', url='http://mock.rulezz/original')
+    original = original.prepare()
+    response = mock.MagicMock()
+    response.request = request
+    response0 = mock.MagicMock()
+    response0.request = original
+    response.history = [response0, mock.MagicMock]
+    log_request(response)
+    assert mocked_logger.info.call_args[0][0] == ("%s Request : " % request.method +
+                                                  "url=%s (redirected) \n " % response.history[0].request.url +
+                                                  "path_url=%s \n " % response.history[0].request.path_url +
+                                                  "headers=%s \n " % request.headers +
+                                                  "body=%s \n " % request.body)
+
+
+@mock.patch('RequestsLibrary.log.logger')
+def test_log_response(mocked_logger):
+    response = mock.MagicMock()
+    response.url = 'http://mock.rulezz'
+    response.request.method = 'GET'
+    response.status_code = 200
+    response.reason = 'OK'
+    response.text = "<html>body</html>"
+    log_response(response)
+    assert mocked_logger.debug.call_args[0][0] == ("%s Response : url=%s \n " % (response.request.method.upper(),
+                                                                                 response.url) +
+                                                   "status=%s, reason=%s \n " % (response.status_code,
+                                                                                 response.reason) +
+                                                   "body=%s \n " % response.text)
+
+
+def test_format_data_to_log_stringtruncated():
+    pass

--- a/utests/test_log.py
+++ b/utests/test_log.py
@@ -1,13 +1,11 @@
 import json
 import os
 
-from requests import Session
-from requests.utils import default_headers
+from requests import Request
 
-from RequestsLibrary.log import format_data_to_log_string
-
-
-SCRIPT_DIR = os.path.dirname(__file__)
+from RequestsLibrary.log import format_data_to_log_string, log_request
+from utests import SCRIPT_DIR
+from utests import mock
 
 
 def test_format_with_data_and_headers_none():
@@ -45,3 +43,16 @@ def test_format_with_file_descriptor():
     with open(os.path.join(SCRIPT_DIR, '../atests/randombytes.bin'), 'rb') as f:
         data_str = format_data_to_log_string(f)
     assert data_str == repr(f)
+
+
+@mock.patch('RequestsLibrary.log.logger')
+def test_log_request(mocked_logger):
+    request = Request(method='get', url='http://mock.rulezz')
+    request = request.prepare()
+    log_request(request)
+    assert mocked_logger.info.call_args[0][0] == ("%s Request : " % request.method +
+                                                  "url=%s \n " % request.url +
+                                                  "path_url=%s \n " % request.path_url +
+                                                  "headers=%s \n " % request.headers +
+                                                  "body=%s \n " % request.body)
+

--- a/utests/test_utils.py
+++ b/utests/test_utils.py
@@ -35,7 +35,7 @@ def test_merge_headers_with_all_none():
 
 def test_merge_headers_with_all():
     session = Session()
-    headers =  {'Content-Type': 'test'}
+    headers = {'Content-Type': 'test'}
     merged = merge_headers(session, headers)
     session.headers.update(headers)
     assert merged == session.headers

--- a/utests/test_utils.py
+++ b/utests/test_utils.py
@@ -1,7 +1,7 @@
 import os
 
-from RequestsLibrary.utils import is_file_descriptor
-
+from requests import Session
+from RequestsLibrary.utils import is_file_descriptor, merge_headers
 
 SCRIPT_DIR = os.path.dirname(__file__)
 
@@ -18,3 +18,24 @@ def test_is_not_file_descriptor():
 def test_is_file_descriptor():
     with open(os.path.join(SCRIPT_DIR, './test_utils.py')) as fd:
         assert is_file_descriptor(fd) is True
+
+
+def test_merge_headers_with_session_headers_only():
+    session = Session()
+    merged = merge_headers(session, None)
+    assert merged == session.headers
+
+
+def test_merge_headers_with_all_none():
+    session = Session()
+    session.headers = None
+    merged = merge_headers(session, None)
+    assert merged == {}
+
+
+def test_merge_headers_with_all():
+    session = Session()
+    headers =  {'Content-Type': 'test'}
+    merged = merge_headers(session, headers)
+    session.headers.update(headers)
+    assert merged == session.headers

--- a/utests/test_utils.py
+++ b/utests/test_utils.py
@@ -1,9 +1,9 @@
 import os
 
 from requests import Session
-from RequestsLibrary.utils import is_file_descriptor, merge_headers
 
-SCRIPT_DIR = os.path.dirname(__file__)
+from RequestsLibrary.utils import is_file_descriptor, merge_headers
+from utests import SCRIPT_DIR
 
 
 def test_none():

--- a/utests/test_utils.py
+++ b/utests/test_utils.py
@@ -1,0 +1,20 @@
+import os
+
+from RequestsLibrary.utils import is_file_descriptor
+
+
+SCRIPT_DIR = os.path.dirname(__file__)
+
+
+def test_none():
+    assert is_file_descriptor(None) is False
+
+
+def test_is_not_file_descriptor():
+    nf = 'a string'
+    assert is_file_descriptor(nf) is False
+
+
+def test_is_file_descriptor():
+    with open(os.path.join(SCRIPT_DIR, './test_utils.py')) as fd:
+        assert is_file_descriptor(fd) is True


### PR DESCRIPTION
Worked on logging in order to simplify and put under test that part with unit tests.
A big change is that request logging is taken from response object **after** the request is executed, this even if conceptually might sound strange actually shows exactly what has been sent to server.

Closes #284 to automatically truncate long body in logs depending on the log level.
Fixes  #283 
