### PR TITLE
Use 'verify' from the session when making requests

### DIFF
--- a/src/RequestsLibrary/RequestsKeywords.py
+++ b/src/RequestsLibrary/RequestsKeywords.py
@@ -114,7 +114,6 @@ class RequestsKeywords(object):
         # cant pass these into the Session anymore
         self.timeout = float(timeout) if timeout is not None else None
         self.cookies = cookies
-        self.verify = verify if self.builtin.convert_to_boolean(verify) is not True else None
 
         s.url = url
 
@@ -940,7 +939,7 @@ class RequestsKeywords(object):
             params=utils.utf8_urlencode(kwargs.pop('params', None)),
             timeout=self._get_timeout(kwargs.pop('timeout', None)),
             cookies=self.cookies,
-            verify=self.verify,
+            verify=session.verify,
             **kwargs)
 
         log.log_request(resp)


### PR DESCRIPTION
'verify' parameter should come from the session. It is not global across all sessions.