### PR TITLE
Check body size from headers before logging

### DIFF
--- a/src/RequestsLibrary/log.py
+++ b/src/RequestsLibrary/log.py
@@ -8,12 +8,26 @@ LOG_CHAR_LIMIT = 10000
 
 
 def log_response(response):
+
+    try:
+        # Passing large body to format_data_to_log_string and
+        # doing the len() of it takes a lot of time and causes high CPU usage.
+        # If body size can be determined from header's 'Content-length' and body
+        # size is larger then the limit, body will not be logged
+        data_len = response.headers.get('Content-length')
+        if int(data_len) > LOG_CHAR_LIMIT and logging.getLogger().level > 10:
+            data = None
+        else:
+            data = response.text
+    except:
+        data = response.text
+
     logger.info("%s Response : url=%s \n " % (response.request.method.upper(),
                                               response.url) +
                 "status=%s, reason=%s \n " % (response.status_code,
                                               response.reason) +
                 "headers=%s \n " % response.headers +
-                "body=%s \n " % format_data_to_log_string(response.text))
+                "body=%s \n " % format_data_to_log_string(data))
 
 
 def log_request(response):


### PR DESCRIPTION
passing large response.text to function and calculating len() of it
takes a lot of time (and CPU) when a application/zip is returned.
This results in test timeouts and hence failures