### PR TITLE
Upgrade to codecov/codecov-action@v2

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -46,7 +46,7 @@ jobs:
         coverage report
         coverage xml
     - name: Update codecov for unit tests
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v2
       with:
         flags: unit
         file: coverage.xml
@@ -59,7 +59,7 @@ jobs:
         coverage report
         coverage xml
     - name: Update codecov for acceptance tests
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v2
       with:
         flags: acceptance
         file: coverage.xml


### PR DESCRIPTION
codecov-action@v1 is officially deprecated since February 1st, 2022 https://github.com/codecov/codecov-action#%EF%B8%8F--deprecration-of-v1

I suggest we use v2 in the ci.