### PR TITLE
Fixes #339 not execute expensive len if log level matches

### DIFF
--- a/src/RequestsLibrary/log.py
+++ b/src/RequestsLibrary/log.py
@@ -39,7 +39,7 @@ def format_data_to_log_string(data, limit=LOG_CHAR_LIMIT):
     if is_file_descriptor(data):
         return repr(data)
 
-    if len(data) > limit and logging.getLogger().level > 10:
+    if logging.getLogger().level > logging.DEBUG and len(data) > limit:
         data = "%s... (set the log level to DEBUG or TRACE to see the full content)" % data[:limit]
 
     return data

--- a/utests/test_log.py
+++ b/utests/test_log.py
@@ -127,6 +127,7 @@ def test_format_data_not_truncate_debug_level(mocked_logger):
     for i in range(0, 100001):
         data = data + str(i)
     mocked_logger.getLogger().level = 10
+    mocked_logger.DEBUG = 10
     truncated = format_data_to_log_string(data)
     assert truncated == data
 
@@ -137,6 +138,7 @@ def test_format_data_not_truncate_trace_level(mocked_logger):
     for i in range(0, 100001):
         data = data + str(i)
     mocked_logger.getLogger().level = 0
+    mocked_logger.DEBUG = 10
     truncated = format_data_to_log_string(data)
     assert truncated == data
 
@@ -147,5 +149,6 @@ def test_format_data_truncate_info_level(mocked_logger):
     for i in range(0, 100001):
         data = data + str(i)
     mocked_logger.getLogger().level = 20
+    mocked_logger.DEBUG = 10
     truncated = format_data_to_log_string(data)
     assert truncated == data[:10000] + '... (set the log level to DEBUG or TRACE to see the full content)'


### PR DESCRIPTION
Basically if you reduce log level truncate will automatically match and the len() method is not executed saving cpu time.

Should solve in a different way #332

It should partially fix #355 at least allow a workaround to skip the test for log level higher than DEBUG.
