### PR TITLE
fix: credentials leakage in request headers

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 requests
 robotframework
 requests_ntlm
+pytest

--- a/src/RequestsLibrary/log.py
+++ b/src/RequestsLibrary/log.py
@@ -16,18 +16,16 @@ def log_response(response):
                 "body=%s \n " % format_data_to_log_string(response.text))
 
 
-def log_request(response):
+def log_request(response, log_headers=False):
     request = response.request
-    if response.history:
-        original_request = response.history[0].request
-        redirected = '(redirected) '
-    else:
-        original_request = request
-        redirected = ''
+    response_history = response.history
+    original_request = response_history[0].request if response_history else request
+    redirected = '(redirected) ' if response_history else ''
+    headers = original_request.headers if log_headers else '{}'
     logger.info("%s Request : " % original_request.method.upper() +
                 "url=%s %s\n " % (original_request.url, redirected) +
                 "path_url=%s \n " % original_request.path_url +
-                "headers=%s \n " % original_request.headers +
+                "headers=%s \n " % headers +
                 "body=%s \n " % format_data_to_log_string(original_request.body))
 
 


### PR DESCRIPTION
The headers request contains the authentication, and it gets printed in the robot log report.

Issue #380 