### PR TITLE
Propagate verify=False from session to requests

### DIFF
--- a/src/RequestsLibrary/RequestsKeywords.py
+++ b/src/RequestsLibrary/RequestsKeywords.py
@@ -34,6 +34,8 @@ class RequestsKeywords(object):
 
         self._capture_output()
 
+        kwargs.update({'verify': session.verify})
+        
         resp = method_function(
             self._merge_url(session, uri),
             timeout=self._get_timeout(kwargs.pop('timeout', None)),


### PR DESCRIPTION
ref:  https://forum.robotframework.org/t/how-to-make-requests-library-ignore-ssl-errors/6790

ref: https://github.com/MarketSquare/robotframework-requests/issues/386