### PR TITLE
Fix acceptance tests with latest flask and werkzeug

### DIFF
--- a/atests/http_server/core.py
+++ b/atests/http_server/core.py
@@ -179,8 +179,8 @@ def redirect_to():
     args_dict = request.args.items()
     args = CaseInsensitiveDict(args_dict)
 
-    # We need to build the response manually and convert to UTF-8 to prevent
-    # werkzeug from "fixing" the URL. This endpoint should set the Location
+    # We need to build the response manually.
+    # This endpoint should set the Location
     # header to the exact string supplied.
     response = app.make_response("")
     response.status_code = 302

--- a/atests/http_server/core.py
+++ b/atests/http_server/core.py
@@ -188,6 +188,6 @@ def redirect_to():
         status_code = int(args["status_code"])
         if status_code >= 300 and status_code < 400:
             response.status_code = status_code
-    response.headers["Location"] = args["url"].encode("utf-8")
+    response.headers["Location"] = args["url"]
 
     return response

--- a/atests/http_server/helpers.py
+++ b/atests/http_server/helpers.py
@@ -13,8 +13,7 @@ import re
 import time
 import os
 from hashlib import md5, sha256, sha512
-from werkzeug.http import parse_authorization_header
-from werkzeug.datastructures import WWWAuthenticate
+from werkzeug.datastructures import WWWAuthenticate, Authorization
 
 from flask import request, make_response
 from six.moves.urllib.parse import urlparse, urlunparse
@@ -357,7 +356,7 @@ def check_digest_auth(user, passwd):
     """Check user authentication using HTTP Digest auth"""
 
     if request.headers.get('Authorization'):
-        credentials = parse_authorization_header(request.headers.get('Authorization'))
+        credentials = Authorization.from_header(request.headers.get('Authorization'))
         if not credentials:
             return
         request_uri = request.script_root + request.path


### PR DESCRIPTION
Fix acceptance tests with latest flask and werkzeug.
The local test http server based on flask and werkzeug was not working with the latest versions. This PR fixes that.