### PR TITLE
Add keyword to get response from last request

### DIFF
--- a/atests/test_requests.robot
+++ b/atests/test_requests.robot
@@ -283,20 +283,20 @@ Trace Request
     ${resp}=    TRACE    ${HTTP_LOCAL_SERVER}/anything
     Status Should Be    OK    ${resp}
 
-Get request with get response
+Get request with last response
     [Tags]    get
     GET    ${HTTP_LOCAL_SERVER}/anything
     Status Should Be    OK
-    ${resp}=    Get response
+    ${resp}=    Last response
     Should be equal    ${resp.status_code}    ${200}
     Should be equal    ${resp.json()}[url]    ${HTTP_LOCAL_SERVER}/anything
 
-Post request with get response
+Post request with last response
     [Tags]    post
     ${data}=   Create dictionary    key1=one    key2=two    key3=3
     POST    ${HTTP_LOCAL_SERVER}/anything    json=${data}
     Status Should Be    OK
-    ${resp}=    Get response
+    ${resp}=    Last response
     Should be equal    ${resp.status_code}    ${200}
     Should be equal    ${resp.json()}[url]    ${HTTP_LOCAL_SERVER}/anything
     Should be equal    ${resp.json()}[json]   ${data}

--- a/atests/test_requests.robot
+++ b/atests/test_requests.robot
@@ -282,3 +282,21 @@ Trace Request
     [Tags]    trace
     ${resp}=    TRACE    ${HTTP_LOCAL_SERVER}/anything
     Status Should Be    OK    ${resp}
+
+Get request with get response
+    [Tags]    get
+    GET    ${HTTP_LOCAL_SERVER}/anything
+    Status Should Be    OK
+    ${resp}=    Get response
+    Should be equal    ${resp.status_code}    ${200}
+    Should be equal    ${resp.json()}[url]    ${HTTP_LOCAL_SERVER}/anything
+
+Post request with get response
+    [Tags]    post
+    ${data}=   Create dictionary    key1=one    key2=two    key3=3
+    POST    ${HTTP_LOCAL_SERVER}/anything    json=${data}
+    Status Should Be    OK
+    ${resp}=    Get response
+    Should be equal    ${resp.status_code}    ${200}
+    Should be equal    ${resp.json()}[url]    ${HTTP_LOCAL_SERVER}/anything
+    Should be equal    ${resp.json()}[json]   ${data}

--- a/src/RequestsLibrary/RequestsKeywords.py
+++ b/src/RequestsLibrary/RequestsKeywords.py
@@ -168,6 +168,13 @@ class RequestsKeywords(object):
         """
         return open(path, "rb")
 
+    @keyword("Get response")
+    def get_response(self) -> requests.Response:
+        """
+        Returns the response from the last request.
+        """
+        return self.last_response
+
     @keyword("GET")
     @warn_if_equal_symbol_in_url_session_less
     def session_less_get(

--- a/src/RequestsLibrary/RequestsKeywords.py
+++ b/src/RequestsLibrary/RequestsKeywords.py
@@ -168,8 +168,8 @@ class RequestsKeywords(object):
         """
         return open(path, "rb")
 
-    @keyword("Get response")
-    def get_response(self) -> requests.Response:
+    @keyword("Last response")
+    def get_last_response(self) -> requests.Response:
         """
         Returns the response from the last request.
         """

--- a/utests/test_RequestsKeywords.py
+++ b/utests/test_RequestsKeywords.py
@@ -1,7 +1,3 @@
-import sys
-
-import pytest
-
 from RequestsLibrary import RequestsLibrary
 from utests import mock
 
@@ -69,14 +65,12 @@ def test_merge_url_with_session_url_path_slash_and_uri_endpoint():
     assert url == 'http://www.domain.com/path/endpoint'
 
 
-@pytest.mark.skipif(sys.version_info < (3, 0), reason="different urljoin handling of double slash")
 def test_merge_url_with_session2trailing_and_endpoint():
     session, keywords = build_mocked_session_keywords('http://www.domain.com//')
     url = keywords._merge_url(session, 'endpoint')
     assert url == 'http://www.domain.com/endpoint'
 
 
-@pytest.mark.skipif(sys.version_info < (3, 0), reason="different urljoin handling of double slash")
 def test_merge_url_with_session_and_slash_endpoint_2trailing():
     session, keywords = build_mocked_session_keywords('http://www.domain.com')
     url = keywords._merge_url(session, '/endpoint//')

--- a/utests/test_SessionKeywords.py
+++ b/utests/test_SessionKeywords.py
@@ -1,4 +1,3 @@
-import sys
 import unittest
 
 from RequestsLibrary import compat
@@ -13,14 +12,12 @@ def test_session_class_extends_keywords_class():
 
 class TestUrlLibWarnings(unittest.TestCase):
 
-    @unittest.skipIf(sys.version_info < (3, 2), "python version doesn't support assertWarns")
     def test_get_default_retry_method_list_not_raise_warning(self):
         with self.assertRaises(AssertionError):
             with self.assertWarns(DeprecationWarning):
                 DEFAULT_RETRY_METHOD_LIST = compat.RetryAdapter.get_default_allowed_methods()
                 assert "GET" in DEFAULT_RETRY_METHOD_LIST
 
-    @unittest.skipIf(sys.version_info < (3, 2), "python version doesn't support assertWarns")
     def test_init_retry_adapter_not_raise_warning(self):
         with self.assertRaises(AssertionError):
             with self.assertWarns(DeprecationWarning):
@@ -29,7 +26,6 @@ class TestUrlLibWarnings(unittest.TestCase):
                                     status_forcelist=[500],
                                     allowed_methods=['GET'])
 
-    @unittest.skipIf(sys.version_info < (3, 2), "python version doesn't support assertWarns")
     def test_create_session_retry_not_raise_warning(self):
         keywords = SessionKeywords()
         with self.assertRaises(AssertionError):


### PR DESCRIPTION
This Pull request adds a keyword to get the response from the last request.
The keyword can be used to create much cleaner testcases because the response does not have to be stored to a variable in the test case.

Example:
```
*** Settings ***
Library     RequestsLibrary

*** Variables ***
${url}    https://httpbin.org/base64
${data}    anlmhcrh7853r042yqtx7rhaohfx,jr0aofds*&*^$IHLFEMXhkdjsxhcc
${base64_data}    YW5sbWhjcmg3ODUzcjA0MnlxdHg3cmhhb2hmeCxqcjBhb2ZkcyomKl4kSUhMRkVNWGhrZGpzeGhjYw==

*** Keywords ***
Response body equals
    [Arguments]    ${data}
    ${response}=   Get response
    Should be equal    ${response.text}    ${data}

*** Test cases ***
httpbin base64 decode
    When get  ${url}/${base64_data}
    Then response body equals    ${data}
```

This PR also removes some skipif decorators from the unit tests for old python versions.