### PR TITLE
Optimize error message

### DIFF
--- a/atests/test_requests.robot
+++ b/atests/test_requests.robot
@@ -84,12 +84,12 @@ Get Request And Fail By Default On Http Error
 
 Get Request And Fail By Expecting A 200 Status
     [Tags]    get
-    Run Keyword And Expect Error    Url: ${HTTP_LOCAL_SERVER}/status/404?param Expected status: 404 != 200
+    Run Keyword And Expect Error    Url: ${HTTP_LOCAL_SERVER}/status/404?param Expected status: 200 != 404
     ...    GET    ${HTTP_LOCAL_SERVER}/status/404    param    200
 
 Get Request And Fail By Expecting A 200 Status With A Message
     [Tags]    get
-    Run Keyword And Expect Error    Custom msg Url: ${HTTP_LOCAL_SERVER}/status/404?param Expected status: 404 != 200
+    Run Keyword And Expect Error    Custom msg Url: ${HTTP_LOCAL_SERVER}/status/404?param Expected status: 200 != 404
     ...    GET    ${HTTP_LOCAL_SERVER}/status/404    param    200    Custom msg
 
 Get Request Expect An Error And Evaluate Response

--- a/atests/test_requests_on_session.robot
+++ b/atests/test_requests_on_session.robot
@@ -84,12 +84,12 @@ Get Request And Fail By Default On Http Error
 
 Get Request And Fail By Expecting A 200 Status
     [Tags]    get
-    Run Keyword And Expect Error    Url: ${HTTP_LOCAL_SERVER}/status/404?param Expected status: 404 != 200
+    Run Keyword And Expect Error    Url: ${HTTP_LOCAL_SERVER}/status/404?param Expected status: 200 != 404
     ...    GET On Session    ${GLOBAL_SESSION}    /status/404    param    200
 
 Get Request And Fail By Expecting A 200 Status With A Message
     [Tags]    get
-    Run Keyword And Expect Error    Custom msg Url: ${HTTP_LOCAL_SERVER}/status/404?param Expected status: 404 != 200
+    Run Keyword And Expect Error    Custom msg Url: ${HTTP_LOCAL_SERVER}/status/404?param Expected status: 200 != 404
     ...    GET On Session    ${GLOBAL_SESSION}    /status/404    param    200    Custom msg
 
 Get Request Expect An Error And Evaluate Response

--- a/atests/test_status_assertions.robot
+++ b/atests/test_status_assertions.robot
@@ -7,7 +7,7 @@ Request And Status Should Be Different
     [Tags]    get    status
     ${resp}=    GET On Session    ${GLOBAL_SESSION}    /status/404    expected_status=any
     Run Keyword And Expect Error
-    ...    Url: ${HTTP_LOCAL_SERVER}/status/404 Expected status: 404 != 201
+    ...    Url: ${HTTP_LOCAL_SERVER}/status/404 Expected status: 201 != 404
     ...    Status Should Be
     ...    201
     ...    ${resp}
@@ -36,7 +36,7 @@ Request And Status Should Be With A Message
     [Tags]    get    status
     ${resp}=    GET On Session    ${GLOBAL_SESSION}    /status/418    expected_status=any
     Run Keyword And Expect Error
-    ...    It should be a teapot! Url: ${HTTP_LOCAL_SERVER}/status/418 Expected status: 418 != 200
+    ...    It should be a teapot! Url: ${HTTP_LOCAL_SERVER}/status/418 Expected status: 200 != 418
     ...    Status Should Be
     ...    OK
     ...    ${resp}
@@ -89,7 +89,7 @@ Assert Status Should Be Fail On The Last Request
     [Tags]    post    status
     POST On Session    ${GLOBAL_SESSION}    /status/500    expected_status=500
     Run Keyword And Expect Error
-    ...    Url: ${HTTP_LOCAL_SERVER}/status/500 Expected status: 500 != 200
+    ...    Url: ${HTTP_LOCAL_SERVER}/status/500 Expected status: 200 != 500
     ...    Status Should Be
     ...    OK
 
@@ -124,6 +124,6 @@ Assert Status Should Be Fail On The Last Session-Less Request
     [Tags]    post    status
     POST    ${HTTP_LOCAL_SERVER}/status/500    expected_status=500
     Run Keyword And Expect Error
-    ...    Url: ${HTTP_LOCAL_SERVER}/status/500 Expected status: 500 != 200
+    ...    Url: ${HTTP_LOCAL_SERVER}/status/500 Expected status: 200 != 500
     ...    Status Should Be
     ...    OK

--- a/src/RequestsLibrary/SessionKeywords.py
+++ b/src/RequestsLibrary/SessionKeywords.py
@@ -629,7 +629,7 @@ class SessionKeywords(RequestsKeywords):
                 expected_status = utils.parse_named_status(expected_status)
             msg = "" if msg is None else "{} ".format(msg)
             msg = "{}Url: {} Expected status".format(msg, resp.url)
-            assert_equal(resp.status_code, expected_status, msg)
+            assert_equal(expected_status, resp.status_code, msg)
 
     def _get_timeout(self, timeout):
         result = timeout if timeout is not None else self.timeout


### PR DESCRIPTION

``` robot
GET    ${HTTP_LOCAL_SERVER}/status/404    param    200    Custom msg
```
Error message:

`Custom msg Url: http://localhost:5010/status/404?param Expected status: 404 != 200`

This is not correct, updated to:

`Custom msg Url: http://localhost:5010/status/404?param Expected status: 200 != 404`